### PR TITLE
Fixing capitalization of logrus package 

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 


### PR DESCRIPTION
I tried to install kickoff and got this output:

> [tw-mbp-tcarr ~]$ go get -u -v -t github.com/dreadl0ck/kickoff
github.com/dreadl0ck/kickoff (download)
github.com/Sirupsen/logrus (download)
github.com/x-cray/logrus-prefixed-formatter (download)
github.com/mgutz/ansi (download)
github.com/mattn/go-colorable (download)
github.com/sirupsen/logrus (download)
can't load package: package github.com/dreadl0ck/kickoff: case-insensitive import collision: "github.com/Sirupsen/logrus" and "github.com/sirupsen/logrus"

I went ahead and fixed the capitalization. It appears to have conflicted with another package.